### PR TITLE
Revert "Added Self Promotion Link"

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,9 +15,6 @@
             <li>
                 <a href="https://git-scm.com/book/">The Git Book</a>
             </li>
-            <li>
-                <a href="https://github.com/theebuddylee">Buddy Turner</a>
-            </li>
             <!-- Add more links here! -->
             
             <li>


### PR DESCRIPTION
Reverts bitcoin-santa-cruz/bitcoin-santa-cruz.github.io#4

Going to have promotion links in wiki instead